### PR TITLE
debian 9.1 no longer uses symlinks to / bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ RUN wget https://keybase.io/justcontainers/key.asc --no-check-certificate -O /tm
     && wget https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz.sig --no-check-certificate -O /tmp/s6-overlay-amd64.tar.gz.sig \
     && gpg --import /tmp/s6-overlay-key.asc \
     && gpg --verify /tmp/s6-overlay-amd64.tar.gz.sig /tmp/s6-overlay-amd64.tar.gz \
-    #Fix for symlinks /bin (debian9), more info ---> https://github.com/just-containers/s6-overlay#bin-and-sbin-are-symlinks 
-    && tar xvfz /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" \
-    && tar xvfz /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin \
+    && tar xvfz /tmp/s6-overlay-amd64.tar.gz -C / \
     && rm -f /tmp/s6-overlay-key.asc \
     && rm -f /tmp/s6-overlay-amd64.tar.gz \
     && rm -f /tmp/s6-overlay-amd64.tar.gz.sig


### PR DESCRIPTION
debian 9.1 no longer uses symlinks to / bin